### PR TITLE
모든 파일 라이선스 명시 완료 및 코드 스타일 가이드 적용 방법

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,25 @@
+# 실 개발 프로젝트를 위해서는 더 많은 내용들과 예외 사항들을 다루고 있는 스타일 가이드 
+# (예: 구글 C++ 스타일 가이드) 사용을 적극 권장함.
+# CSE3210 style guide + Google c++ style guide에 대한 .clang-format
+
+---
+Language: Cpp # 언어 설정 (C++ 코드에 적용) (Google)
+BasedOnStyle: Google # Google 스타일을 기본으로 사용 (Google)
+IndentWidth: 2 # 들여쓰기 폭을 2 스페이스로 설정 (CSE3210 스타일 준수)
+ColumnLimit: 80 # 한 줄 최대 길이를 80자로 제한 (CSE3210 스타일 준수)
+UseTab: Never # 들여쓰기에 탭 대신 스페이스 사용 (CSE3210 스타일 준수)
+BreakBeforeBraces: Attach # 중괄호를 같은 줄에 배치 (Google)
+AllowShortFunctionsOnASingleLine: InlineOnly # 짧은 함수는 한 줄에 작성 (Google)
+IncludeBlocks: Regroup # `#include` 헤더를 블록으로 묶어서 정렬 (Google)
+SortIncludes: true # `#include` 헤더를 알파벳 순서로 정렬 (CSE3210 스타일 준수)
+NamespaceIndentation: None # 네임스페이스 내부 들여쓰기 금지 (CSE3210 스타일 준수)
+AccessModifierOffset: -2 # 접근 제어자(public, private 등) 들여쓰기 비활성화 (Google)
+AlignTrailingComments: true # 줄 끝 주석을 정렬하여 가독성 향상 (Google)
+SpacesBeforeTrailingComments: 1 # 줄 끝 주석 전에 한 칸의 스페이스 추가 (Google)
+KeepEmptyLinesAtTheStartOfBlocks: false # 블록 시작 부분의 빈 줄 제거 (Google)
+AlwaysBreakAfterReturnType: None # 반환 타입과 함수 이름을 같은 줄에 유지 (Google)
+SpaceBeforeParens: ControlStatements # 제어문 (if, while, for)에서 괄호 앞에 스페이스 삽입 (Google)
+IndentPPDirectives: None # 전처리기 지시문 (#define 등) 들여쓰기 비활성화 (Google)
+ConstructorInitializerIndentWidth: 2 # 생성자 초기화 리스트의 들여쓰기 폭을 2로 설정 (Google)
+PointerAlignment: Left # 포인터와 참조(&)를 변수 이름 왼쪽에 배치 (Google)
+---

--- a/.github/workflows/OSAP_001_GitHubTea_test.cpp.yaml
+++ b/.github/workflows/OSAP_001_GitHubTea_test.cpp.yaml
@@ -1,3 +1,13 @@
+# File Name: FileName.cpp
+# Copyright (c) 2024 GitHubTea
+#
+# This software is distributed under the MIT License.
+# For more details on the MIT License, please refer to the LICENSE file in this project.
+# This software is provided "as is," without any warranty of any kind.
+#
+# Author: GitHubTea
+# Date: 2024-11-28
+
 name: AVL Tree Google Test
 
 on:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,13 @@
+#  File Name: FileName.cpp
+#  Copyright (c) 2024 GitHubTea
+#
+#  This software is distributed under the MIT License.
+#  For more details on the MIT License, please refer to the LICENSE file in this project.
+#  This software is provided "as is," without any warranty of any kind.
+#
+#  Author: GitHubTea
+#  Date: 2024-11-28
+
 cmake_minimum_required(VERSION 3.14)
 project(INHA_OSAP_001_GitHubTea)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,13 @@
+#  File Name: FileName.cpp
+#  Copyright (c) 2024 GitHubTea
+#
+#  This software is distributed under the MIT License.
+#  For more details on the MIT License, please refer to the LICENSE file in this project.
+#  This software is provided "as is," without any warranty of any kind.
+#
+#  Author: GitHubTea
+#  Date: 2024-11-28
+
 # 채점 서버와 같은 환경
 FROM ubuntu:18.04
 

--- a/header/OSAP_001_GitHubTea_AVLtree.h
+++ b/header/OSAP_001_GitHubTea_AVLtree.h
@@ -18,6 +18,26 @@ public:
 	int Rank(int key) const;
 	void Insert(int key);
 	void Erase(int key);
+
+    AVLTree(); // AVLTree instance에 대한 생성자
+    ~AVLTree(); // AVLTree instance에 대한 소멸자
+
+    void set_root(int); // member data root_에 대한 setter
+    void set_size(int); // member data size_에 대한 setter
+    void set_height(int); // member data height_에 대한 setter
+
+    bool Empty() const; // set이 비어 있다면 1을, 아니라면 0을 return함
+    int Size() const; // 현재 tree에 존재하는 node들의 개수를 출력함
+    int Height() const; // 전체 tree의 height를 return함
+    int Height(int) const; // node의 key를 입력받고, 그 node의 높이를 출력함
+    int Depth(int) const; // node의 key를 입력받고, 그 node의 깊이를 출력함
+    int Ancestor(int) const; // node의 key를 입력받고, 그 node의 Ancestors들의 key의 합을 return함
+    int MinDescendant(int) const; // node의 key를 입력받고, 그 node의 Descendant들 중 가장 작은 key를 return함
+    int MaxDescendant(int) const; // node의 key를 입력받고, 그 node의 Descendant들 중 가장 큰 key를 return함
+    int Rank(int) const; // node의 key를 입력받고, 그 node의 rank를 출력함
+    void Insert(int); // tree에 새로운 Node를 삽입함
+    void Erase(int);  // node의 key를 입력받고, 그 node를 삭제함
+
 private:
 	Node* root;
 	int size;

--- a/header/OSAP_001_GitHubTea_AVLtree.h
+++ b/header/OSAP_001_GitHubTea_AVLtree.h
@@ -1,3 +1,15 @@
+/*
+   File Name: FileName.cpp
+   Copyright (c) 2024 GitHubTea
+
+   This software is distributed under the MIT License.
+   For more details on the MIT License, please refer to the LICENSE file in this project.
+   This software is provided "as is," without any warranty of any kind.
+
+   Author: GitHubTea
+   Date: 2024-11-28
+*/ 
+
 #ifndef AVL_TREE_OSAP_001_GITHUBTEA_AVLTREE_H_
 #define AVL_TREE_OSAP_001_GITHUBTEA_AVLTREE_H_
 

--- a/header/OSAP_001_GitHubTea_Node.h
+++ b/header/OSAP_001_GitHubTea_Node.h
@@ -15,6 +15,17 @@ public:
     void set_parent_node_(Node*);
     void set_right_node_(Node*);
     void set_left_node_(Node*);
+
+	int key() const; // member data key_에 대한 getter
+	Node* left_node() const; // left child node의 주소에 대한 getter
+	Node* right_node() const; //right child node의 주소에 대한 getter
+	int height() const; // member data height_에 대한 getter
+
+	void set_key(); // member data key_에 대한 setter
+	void set_left_node(Node*); // left child node의 주소에 대한 setter
+	void set_right_node(Node*); //right child node의 주소에 대한 setter
+	void set_height(int); // member data height_에 대한 getter
+
 private:
     int key;
     int height;

--- a/header/OSAP_001_GitHubTea_Node.h
+++ b/header/OSAP_001_GitHubTea_Node.h
@@ -1,3 +1,15 @@
+/*
+   File Name: FileName.cpp
+   Copyright (c) 2024 GitHubTea
+
+   This software is distributed under the MIT License.
+   For more details on the MIT License, please refer to the LICENSE file in this project.
+   This software is provided "as is," without any warranty of any kind.
+
+   Author: GitHubTea
+   Date: 2024-11-28
+*/ 
+
 #ifndef AVL_TREE_OSAP_001_GITHUBTEA_NODE_H_
 #define AVL_TREE_OSAP_001_GITHUBTEA_NODE_H_
 

--- a/source/OSAP_001_GitHubTea_AVLtree.cpp
+++ b/source/OSAP_001_GitHubTea_AVLtree.cpp
@@ -1,3 +1,15 @@
+/*
+   File Name: FileName.cpp
+   Copyright (c) 2024 GitHubTea
+
+   This software is distributed under the MIT License.
+   For more details on the MIT License, please refer to the LICENSE file in this project.
+   This software is provided "as is," without any warranty of any kind.
+
+   Author: GitHubTea
+   Date: 2024-11-28
+*/ 
+
 #include "../header/OSAP_001_GitHubTea_AVLtree.h"
 #include <algorithm>
 

--- a/source/OSAP_001_GitHubTea_Node.cpp
+++ b/source/OSAP_001_GitHubTea_Node.cpp
@@ -1,3 +1,15 @@
+/*
+   File Name: FileName.cpp
+   Copyright (c) 2024 GitHubTea
+
+   This software is distributed under the MIT License.
+   For more details on the MIT License, please refer to the LICENSE file in this project.
+   This software is provided "as is," without any warranty of any kind.
+
+   Author: GitHubTea
+   Date: 2024-11-28
+*/ 
+
 #include "../header/OSAP_001_GitHubTea_Node.h"
 
 Node::Node(int _key)

--- a/source/OSAP_001_GitHubTea_main.cpp
+++ b/source/OSAP_001_GitHubTea_main.cpp
@@ -1,3 +1,15 @@
+/*
+   File Name: FileName.cpp
+   Copyright (c) 2024 GitHubTea
+
+   This software is distributed under the MIT License.
+   For more details on the MIT License, please refer to the LICENSE file in this project.
+   This software is provided "as is," without any warranty of any kind.
+
+   Author: GitHubTea
+   Date: 2024-11-28
+*/ 
+
 #include "../header/OSAP_001_GitHubTea_Node.h"
 #include "../header/OSAP_001_GitHubTea_AVLtree.h"
 #include "./OSAP_001_GitHubTea_Node.cpp"

--- a/test/OSAP_001_GitHubTea_AVLtree_test.cpp
+++ b/test/OSAP_001_GitHubTea_AVLtree_test.cpp
@@ -1,3 +1,15 @@
+/*
+   File Name: FileName.cpp
+   Copyright (c) 2024 GitHubTea
+
+   This software is distributed under the MIT License.
+   For more details on the MIT License, please refer to the LICENSE file in this project.
+   This software is provided "as is," without any warranty of any kind.
+
+   Author: GitHubTea
+   Date: 2024-11-28
+*/ 
+
 #include "header/OSAP_001_GitHubTea_AVLtree.h"
 #include "source/OSAP_001_GitHubTea_AVLtree.cpp"
 #include <gtest/gtest.h>


### PR DESCRIPTION
올려주신 파일들에 라이선스 추가하였습니다.

### .clang-format 적용 방법
1. Clang-Format 확장판 설치
우선 VSCode 확장판에서 Clang-Format를 설치합니다.

2. Ubuntu/WSL 터미널
코드의 특정 부분에 적용하려면 아래 명령어를 사용합니다:
`clang-format -i {스타일 가이드 적용할 파일 이름}.cpp`

