### PR TITLE
docs: 파일 확장자 변경 및 doxygen 주석 적용

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,9 @@ message(${CMAKE_HOME_DIRECTORY})
 
 add_executable(
   avl_tree_test
-  test/OSAP_001_GitHubTea_AVLtree_AVLTree_test.cpp
-  test/OSAP_001_GitHubTea_AVLtree_Node_test.cpp
-  source/OSAP_001_GitHubTea_AVLtree_Node.cpp
+  test/OSAP_001_GitHubTea_AVLtree_AVLTree_test.cc
+  test/OSAP_001_GitHubTea_AVLtree_Node_test.cc
+  source/OSAP_001_GitHubTea_AVLtree_Node.cc
 )
 target_link_libraries(
   avl_tree_test

--- a/header/OSAP_001_GitHubTea_AVLtree_AVLTree.h
+++ b/header/OSAP_001_GitHubTea_AVLtree_AVLTree.h
@@ -1,5 +1,5 @@
 ﻿/****************************************************************************************
-   File Name: OSAP_001_GitHubTea_AVLtree.h
+   File Name: OSAP_001_GitHubTea_AVLtree_AVLTree.h
    Copyright (c) 2024 GitHubTea
 
    This software is distributed under the MIT License.
@@ -15,42 +15,130 @@
 
 #include "header/OSAP_001_GitHubTea_AVLtree_Node.h"
 
+/**
+ * @class AVLTree
+ * @brief AVL Tree를 구현한 클래스
+ * @details AVL Tree는 균형 이진 탐색 트리의 일종으로, 삽입과 삭제 시 높이
+ * 균형을 유지한다.
+ */
 class AVLTree {
 public:
-  // public method 
-  AVLTree();                         // normal constructor 
-  bool IsRoot(int);                  // AVL Tree에 매개변수 key값을 가진 노드가 루트 노드인지 판별하여 bool로 return
-  bool IsExist(int);                 // AVL Tree에 매개변수 key값을 가진 노드가 존재하는지 판별하여 bool로 return
-  bool Empty() const;                // AVL Tree가 비어있는지 판별하여 bool로 return
-  int Size() const;                  // AVL Tree에 저장된 전체 노드 개수를 int로 return
-  int Height() const;                // AVL Tree의 root Node의 높이를 int로 return
-  int Height(int);                   // AVL Tree의 매개변수 key값을 가진 노드를 찾아 높이를 int로 return
-  int Depth(int);                    // AVL Tree의 매개변수 key값을 가진 노드를 찾아 깊이를 int로 return
-  int Find(int);                     // AVL Tree의 매개변수 key값을 가진 노드를 찾아 깊이와 높이의 합을 출력
-  int MinDescendant(int);            // AVL Tree의 매개변수 key값을 가진 노드의 서브트리에서 최솟값을 int로 return
-  int MaxDescendant(int);            // AVL Tree의 매개변수 key값을 가진 노드의 서브트리에서 최댓값을 int로 return
-  int AncestorKeySum(int);           // AVL Tree의 매개변수 key값을 가진 노드를 찾아 부모노드부터 루트까지의 경로의 Node들의 keyW값의 합을 int로 return
-  void Insert(int);                  // AVL Tree의 매개변수 key값을 가진 노드를 삽입
-  int Rank(int);                     // AVL Tree의 매개변수 key값을 가진 노드를 찾아 순위를 return
-  void Erase(int);                   // AVL Tree의 매개변수 key값을 가진 노드를 찾아 깊이와 높이의 합을 출력하고 해당 노드를 삭제
+  /**
+   * @brief AVLTree의 기본 생성자
+   */
+  AVLTree();
+
+  /**
+   * @brief AVL Tree에 매개변수 key값을 가진 노드가 루트 노드인지 판별
+   * @param key 확인할 노드의 key 값
+   * @return 루트 노드라면 true, 아니면 false
+   */
+  bool IsRoot(int);
+
+  /**
+   * @brief AVL Tree에 매개변수 key값을 가진 노드가 존재하는지 판별
+   * @param key 확인할 노드의 key 값
+   * @return 존재하면 true, 아니면 false
+   */
+  bool IsExist(int);
+
+  /**
+   * @brief AVL Tree가 비어있는지 판별
+   * @return 비어있으면 true, 아니면 false
+   */
+  bool Empty() const;
+
+  /**
+   * @brief AVL Tree에 저장된 전체 노드 개수를 반환
+   * @return AVL Tree의 전체 노드 개수
+   */
+  int Size() const;
+
+  /**
+   * @brief AVL Tree의 root Node의 높이를 반환
+   * @return 루트 노드의 높이, 트리가 비어있으면 -1
+   */
+  int Height() const;
+
+  /**
+   * @brief AVL Tree의 매개변수 key값을 가진 노드를 찾아 높이를 반환
+   * @param key 확인할 노드의 key 값
+   * @return 노드의 높이, 존재하지 않으면 0
+   */
+  int Height(int);
+
+  /**
+   * @brief AVL Tree의 매개변수 key값을 가진 노드를 찾아 깊이를 반환
+   * @param key 확인할 노드의 key 값
+   * @return 노드의 깊이, 존재하지 않으면 0
+   */
+  int Depth(int);
+
+  /**
+   * @brief AVL Tree의 매개변수 key값을 가진 노드를 찾아 깊이와 높이의 합을 반환
+   * @param key 확인할 노드의 key 값
+   * @return 깊이와 높이의 합, 존재하지 않으면 0
+   */
+  int Find(int);
+
+  /**
+   * @brief AVL Tree의 매개변수 key값을 가진 노드의 서브트리에서 최솟값을 반환
+   * @param key 확인할 노드의 key 값
+   * @return 서브트리의 최솟값, 존재하지 않으면 0
+   */
+  int MinDescendant(int);
+
+  /**
+   * @brief AVL Tree의 매개변수 key값을 가진 노드의 서브트리에서 최댓값을 반환
+   * @param key 확인할 노드의 key 값
+   * @return 서브트리의 최댓값, 존재하지 않으면 0
+   */
+  int MaxDescendant(int);
+
+  /**
+   * @brief AVL Tree의 매개변수 key값을 가진 노드의 조상 노드들의 key값의 합을
+   * 반환
+   * @param key 확인할 노드의 key 값
+   * @return 조상 노드들의 key 값의 합, 존재하지 않으면 0
+   */
+  int AncestorKeySum(int);
+
+  /**
+   * @brief AVL Tree에 매개변수 key값을 가진 노드를 삽입
+   * @param key 삽입할 노드의 key 값
+   */
+  void Insert(int);
+
+  /**
+   * @brief AVL Tree의 매개변수 key값을 가진 노드를 찾아 순위를 반환
+   * @param key 확인할 노드의 key 값
+   * @return key값을 가진 노드의 순위, 존재하지 않으면 0
+   */
+  int Rank(int);
+
+  /**
+   * @brief AVL Tree의 매개변수 key값을 가진 노드를 삭제
+   * @param key 삭제할 노드의 key 값
+   */
+  void Erase(int);
 
 private:
-  // attribute
+  /// attribute
   Node* root_;                       // AVL Tree Root Node
   int size_;                         // AVL Tree 전체 사이즈
 
   // private method
-  int Difference(Node*);             // 매개변수 curNode의 두 자식 노드의 차를 return
-  void UpdateHeight(Node*);          // 매개변수 curNode의 높이를 업데이트함
-  void UpdateSubtreeSize(Node*);     // 매개변수 curNode의 서브트리 사이즈를 업데이트함
-  Node* LeftLeftRotation(Node*);     // Left-Left Rotation 수행 Node*로 return
-  Node* RightRightRotation(Node*);   // Right-Right Rotation 수행 Node*로 return
-  Node* LeftRightRotation(Node*);    // Left-Right Rotation 수행 Node*로 return
-  Node* RightLeftRotation(Node*);    // Right-Left Rotation 수행 후 Node*로 return
-  Node* Balance(Node*);              // 매개변수 curNode에 알맞은 회전을 수행 후 Node*로 return
-  Node* Search(Node*, int);          // 매개변수 curNode를 root로 하는 AVL Tree에서 key값을 가진 노드를 찾아 Node*로 return
-  int FindMin(Node*);                // 서브트리의 노드 중 가장 작은 키값을 int로 return
-  int FindMax(Node*);                // 서브트리의 노드 중 가장 큰 키값을 int로 return
+  int Difference(Node*);             // 매개변수 curNode의 두 자식 노드의 차를 반환
+  void UpdateHeight(Node*);          // 매개변수 curNode의 높이를 업데이트
+  void UpdateSubtreeSize(Node*);     // 매개변수 curNode의 서브트리 크기를 업데이트
+  Node* LeftLeftRotation(Node*);     // Left-Left Rotation 수행
+  Node* RightRightRotation(Node*);   // Right-Right Rotation 수행
+  Node* LeftRightRotation(Node*);    // Left-Right Rotation 수행
+  Node* RightLeftRotation(Node*);    // Right-Left Rotation 수행
+  Node* Balance(Node*);              // 매개변수 curNode에 알맞은 회전을 수행
+  Node* Search(Node*, int);          // 매개변수 curNode를 root로 하는 AVL Tree에서 key값을 가진 노드를 검색
+  int FindMin(Node*);                // 서브트리의 노드 중 가장 작은 키값을 반환
+  int FindMax(Node*);                // 서브트리의 노드 중 가장 큰 키값을 반환
 };
 
 #endif // !AVL_TREE_OSAP_001_GITHUBTEA_AVLTREE_AVLTREE_H_

--- a/header/OSAP_001_GitHubTea_AVLtree_Node.h
+++ b/header/OSAP_001_GitHubTea_AVLtree_Node.h
@@ -1,10 +1,10 @@
 /****************************************************************************************
-   File Name: OSAP_001_GitHubTea_Node.h
+   File Name: OSAP_001_GitHubTea_AVLtree_Node.h
    Copyright (c) 2024 GitHubTea
 
    This software is distributed under the MIT License.
-   For more details on the MIT License, please refer to the LICENSE file in this project.
-   This software is provided "as is," without any warranty of any kind.
+   For more details on the MIT License, please refer to the LICENSE file in this
+project. This software is provided "as is," without any warranty of any kind.
 
    Author: GitHubTea
    Date: 2024-11-28
@@ -13,38 +13,76 @@
 #ifndef AVL_TREE_OSAP_001_GITHUBTEA_AVLTREE_NODE_H_
 #define AVL_TREE_OSAP_001_GITHUBTEA_AVLTREE_NODE_H_
 
+/**
+ * @class Node
+ * @brief AVL Tree의 노드를 나타내는 클래스
+ * @details 각 Node 객체는 트리의 키, 높이, 서브트리 크기, 부모 및 자식 노드에
+ * 대한 정보를 포함한다.
+ */
 class Node {
 public:
-  // public method 
+  /// @brief 기본 생성자
+  Node();
 
-  // 생성자
-  Node();        // 기본 생성자 
-  Node(int key_); // 매개변수 생성자
+  /// @brief 매개변수를 사용한 생성자
+  /// @param key_ 노드의 초기 key 값
+  Node(int key_);
 
-  // getter
+  /// @brief 노드의 key 값을 반환
+  /// @return 노드의 key 값
   int get_key() const;
+
+  /// @brief 노드의 높이를 반환
+  /// @return 노드의 높이
   int get_height() const;
+
+  /// @brief 서브트리의 노드 개수를 반환
+  /// @return 서브트리의 노드 개수
   int get_subtree_size() const;
+
+  /// @brief 부모 노드를 반환
+  /// @return 부모 노드의 포인터
   Node* get_parent_node() const;
+
+  /// @brief 왼쪽 자식 노드를 반환
+  /// @return 왼쪽 자식 노드의 포인터
   Node* get_left_node() const;
+
+  /// @brief 오른쪽 자식 노드를 반환
+  /// @return 오른쪽 자식 노드의 포인터
   Node* get_right_node() const;
 
-  // setter
-  void set_key(int);
-  void set_height(int);
-  void set_subtree_size(int);
-  void set_parent_node(Node*);
-  void set_right_node(Node*);
-  void set_left_node(Node*);
+  /// @brief 노드의 key 값을 설정
+  /// @param key 설정할 key 값
+  void set_key(int key);
+
+  /// @brief 노드의 높이를 설정
+  /// @param height 설정할 높이 값
+  void set_height(int height);
+
+  /// @brief 서브트리의 노드 개수를 설정
+  /// @param size 설정할 서브트리 크기
+  void set_subtree_size(int size);
+
+  /// @brief 부모 노드를 설정
+  /// @param parent 설정할 부모 노드 포인터
+  void set_parent_node(Node* parent);
+
+  /// @brief 오른쪽 자식 노드를 설정
+  /// @param right 설정할 오른쪽 자식 노드 포인터
+  void set_right_node(Node* right);
+
+  /// @brief 왼쪽 자식 노드를 설정
+  /// @param left 설정할 왼쪽 자식 노드 포인터
+  void set_left_node(Node* left);
 
 private:
-  int key_;          // 키
-  int height_;       // 트리에서의 높이
-  int subtree_size_; // 서브트리의 전체 노드 개수
-  Node* parent_;     // 부모 노드 포인터
-  Node* left_;       // 왼쪽 자식 노드 포인터
-  Node* right_;      // 오른쪽 자식 노드 포인터
+  int key_;          ///< 노드의 key 값
+  int height_;       ///< 트리에서의 높이
+  int subtree_size_; ///< 서브트리의 전체 노드 개수
+  Node* parent_;     ///< 부모 노드의 포인터
+  Node* left_;       ///< 왼쪽 자식 노드의 포인터
+  Node* right_;      ///< 오른쪽 자식 노드의 포인터
 };
 
-
-#endif // !AVL_TREE_OSAP_001_GITHUBTEA_AVLTREE_NODE_H_
+#endif // AVL_TREE_OSAP_001_GITHUBTEA_AVLTREE_NODE_H_

--- a/source/OSAP_001_GitHubTea_AVLtree_AVLTree.cc
+++ b/source/OSAP_001_GitHubTea_AVLtree_AVLTree.cc
@@ -1,5 +1,5 @@
 /****************************************************************************************
-   File Name: OSAP_001_GitHubTea_AVLtree.cpp
+   File Name: OSAP_001_GitHubTea_AVLtree_AVLTree.cpp
    Copyright (c) 2024 GitHubTea
 
    This software is distributed under the MIT License.

--- a/source/OSAP_001_GitHubTea_AVLtree_AVLTree.cc
+++ b/source/OSAP_001_GitHubTea_AVLtree_AVLTree.cc
@@ -1,5 +1,5 @@
 /****************************************************************************************
-   File Name: OSAP_001_GitHubTea_AVLtree_AVLTree.cpp
+   File Name: OSAP_001_GitHubTea_AVLtree_AVLTree.cc
    Copyright (c) 2024 GitHubTea
 
    This software is distributed under the MIT License.

--- a/source/OSAP_001_GitHubTea_AVLtree_Node.cc
+++ b/source/OSAP_001_GitHubTea_AVLtree_Node.cc
@@ -1,10 +1,10 @@
 ﻿/****************************************************************************************
-   File Name: OSAP_001_GitHubTea_Node.cpp
+   File Name: OSAP_001_GitHubTea_AVLtree_Node.cpp
    Copyright (c) 2024 GitHubTea
 
    This software is distributed under the MIT License.
-   For more details on the MIT License, please refer to the LICENSE file in this project.
-   This software is provided "as is," without any warranty of any kind.
+   For more details on the MIT License, please refer to the LICENSE file in this
+project. This software is provided "as is," without any warranty of any kind.
 
    Author: GitHubTea
    Date: 2024-11-28
@@ -12,7 +12,7 @@
 
 #include "header/OSAP_001_GitHubTea_AVLtree_Node.h"
 
-// public method  
+// public method
 
 // 기본 생성자
 Node::Node()

--- a/source/OSAP_001_GitHubTea_AVLtree_Node.cc
+++ b/source/OSAP_001_GitHubTea_AVLtree_Node.cc
@@ -1,5 +1,5 @@
 ﻿/****************************************************************************************
-   File Name: OSAP_001_GitHubTea_AVLtree_Node.cpp
+   File Name: OSAP_001_GitHubTea_AVLtree_Node.cc
    Copyright (c) 2024 GitHubTea
 
    This software is distributed under the MIT License.

--- a/source/OSAP_001_GitHubTea_AVLtree_main.cc
+++ b/source/OSAP_001_GitHubTea_AVLtree_main.cc
@@ -1,5 +1,5 @@
 ﻿/****************************************************************************************
-   File Name: OSAP_001_GitHubTea_AVLtree_main.cpp
+   File Name: OSAP_001_GitHubTea_AVLtree_main.cc
    Copyright (c) 2024 GitHubTea
 
    This software is distributed under the MIT License.

--- a/source/OSAP_001_GitHubTea_AVLtree_main.cc
+++ b/source/OSAP_001_GitHubTea_AVLtree_main.cc
@@ -1,5 +1,5 @@
 ﻿/****************************************************************************************
-   File Name: OSAP_001_GitHubTea_main.cpp
+   File Name: OSAP_001_GitHubTea_AVLtree_main.cpp
    Copyright (c) 2024 GitHubTea
 
    This software is distributed under the MIT License.

--- a/test/OSAP_001_GitHubTea_AVLtree_AVLTree_test.cc
+++ b/test/OSAP_001_GitHubTea_AVLtree_AVLTree_test.cc
@@ -1,5 +1,5 @@
 /****************************************************************************************
-   File Name: OSAP_001_GitHubTea_AVLtree_AVLTree_test.cpp
+   File Name: OSAP_001_GitHubTea_AVLtree_AVLTree_test.cc
    Copyright (c) 2024 GitHubTea
 
    This software is distributed under the MIT License.
@@ -17,7 +17,7 @@ project. This software is provided "as is," without any warranty of any kind.
 
 #include <iostream>
 
-#include "source/OSAP_001_GitHubTea_AVLtree_AVLTree.cpp"
+#include "source/OSAP_001_GitHubTea_AVLtree_AVLTree.cc"
 using namespace testing;
 using namespace std;
 

--- a/test/OSAP_001_GitHubTea_AVLtree_AVLTree_test.cc
+++ b/test/OSAP_001_GitHubTea_AVLtree_AVLTree_test.cc
@@ -1,5 +1,5 @@
 /****************************************************************************************
-   File Name: OSAP_001_GitHubTea_AVLtree_test.cpp
+   File Name: OSAP_001_GitHubTea_AVLtree_AVLTree_test.cpp
    Copyright (c) 2024 GitHubTea
 
    This software is distributed under the MIT License.
@@ -204,14 +204,15 @@ TEST_F(AVLTreeTestFixture, UpdateSubtreeSizeMethodTest) {
 TEST_F(AVLTreeTestFixture, LeftLeftRotationMethodTest) {
   Node* parent = avl_tree_.Search(avl_tree_.root_, 50012);
   Node* new_parent = avl_tree_.LeftLeftRotation(parent); // 왼쪽-왼쪽 회전
-  EXPECT_EQ(new_parent->key_, 1); // 회전 후 부모 노드가 변경되어야 함
+  EXPECT_EQ(new_parent->get_key(), 1); // 회전 후 부모 노드가 변경되어야 함
 }
 
 // RihtRightRotation() 함수에 대한 test 수행
 TEST_F(AVLTreeTestFixture, RightRightRotationMethodTest) {
   Node* parent = avl_tree_.Search(avl_tree_.root_, 234191);
   Node* new_parent = avl_tree_.RightRightRotation(parent); // 오른쪽-오른쪽 회전
-  EXPECT_EQ(new_parent->key_, 300000); // 회전 후 부모 노드가 변경되어야 함
+  EXPECT_EQ(new_parent->get_key(),
+            300000); // 회전 후 부모 노드가 변경되어야 함
 }
 
 TEST_F(AVLTreeTestFixture, BalanceMethodTest) {
@@ -234,7 +235,7 @@ TEST_F(AVLTreeTestFixture, BalanceMethodTest) {
 // Search() 함수에 대한 test 수행
 TEST_F(AVLTreeTestFixture, SearchMethodTest) {
   Node* found_Node = avl_tree_.Search(avl_tree_.root_, 50012);
-  EXPECT_EQ(found_Node->key_,
+  EXPECT_EQ(found_Node->get_key(),
             50012); // 찾은 노드가 올바른 key를 가지고 있어야 함
 
   Node* not_found_Node =
@@ -257,7 +258,7 @@ TEST_F(AVLTreeTestFixture, FindMaxMethodTest) {
 
 // IsRoot() 함수에 대한 test 수행
 TEST_F(AVLTreeTestFixture, IsRootMethodTest) {
-  EXPECT_EQ(avl_tree_.root_->key_, 100241);
+  EXPECT_EQ(avl_tree_.root_->get_key(), 100241);
 }
 
 // IsExist() 함수에 대한 test 수행

--- a/test/OSAP_001_GitHubTea_AVLtree_Node_test.cc
+++ b/test/OSAP_001_GitHubTea_AVLtree_Node_test.cc
@@ -1,5 +1,5 @@
 /****************************************************************************************
-   File Name: OSAP_001_GitHubTea_Node_test.cpp
+   File Name: OSAP_001_GitHubTea_AVLtree_Node_test.cpp
    Copyright (c) 2024 GitHubTea
 
    This software is distributed under the MIT License.

--- a/test/OSAP_001_GitHubTea_AVLtree_Node_test.cc
+++ b/test/OSAP_001_GitHubTea_AVLtree_Node_test.cc
@@ -1,5 +1,5 @@
 /****************************************************************************************
-   File Name: OSAP_001_GitHubTea_AVLtree_Node_test.cpp
+   File Name: OSAP_001_GitHubTea_AVLtree_Node_test.cc
    Copyright (c) 2024 GitHubTea
 
    This software is distributed under the MIT License.


### PR DESCRIPTION
-CSE3210 스타일가이드에 따라 확장자를 cpp에서 cc로 변경 후 이에 맞춰 include문, 주석 또한 cpp를 cc로 변경하였습니다.
-doxygen 주석을 적용하였습니다. 헤더파일 public 단에 있는 주석에만 적용하여 문서화하였습니다.

체크 부탁드립니다 !